### PR TITLE
Refactor plugin config for lolcommits 0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
+ - 2.5.0
  - ruby-head
 
 before_install:
- - gem install bundler -v 1.13.7
+ - gem update --system
  - git --version
  - git config --global user.email "lol@commits.org"
  - git config --global user.name "Lolcommits"

--- a/lib/lolcommits/plugin/tumblr.rb
+++ b/lib/lolcommits/plugin/tumblr.rb
@@ -14,15 +14,6 @@ module Lolcommits
       TUMBLR_CONSUMER_SECRET = 'qWuvxgFUR2YyWKtbWOkDTMAiBEbj7ZGaNLaNQPba0PI1N4JpBs'.freeze
 
       ##
-      # Returns the name of the plugin to identify the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'tumblr'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process. Uploading happens when a new capture is ready.
       #
@@ -50,11 +41,11 @@ module Lolcommits
       #
       def run_capture_ready
         print "*** Posting to Tumblr ... "
-        post = client.photo(configuration['tumblr_name'], data: runner.main_image)
+        post = client.photo(configuration[:tumblr_name], data: runner.main_image)
 
         if post.key?('id')
           post_url = tumblr_post_url(post)
-          open_url(post_url) if configuration['open_url']
+          open_url(post_url) if configuration[:open_url]
           print "done! #{post_url}\n"
         else
           print "Post FAILED! #{post.inspect}"
@@ -64,15 +55,14 @@ module Lolcommits
       end
 
       ##
-      # Returns true if the plugin has been configured.
+      # Returns true if the plugin has been configured correctly
       #
-      # @return [Boolean] true/false indicating if plugin is configured
+      # @return [Boolean] true/false indicating if plugin has a valid config
       #
-      def configured?
-        !!(configuration['enabled'] &&
-           configuration['access_token'] &&
-           configuration['secret'] &&
-           configuration['tumblr_name'])
+      def valid_configuration?
+        !!(configuration[:access_token] &&
+           configuration[:secret] &&
+           configuration[:tumblr_name])
       end
 
       ##
@@ -87,7 +77,7 @@ module Lolcommits
       def configure_options!
         options = super
         # ask user to configure tokens if enabling
-        if options['enabled']
+        if options[:enabled]
           auth_config = configure_auth!
           return unless auth_config
           options = options.merge(auth_config).merge(configure_tumblr)
@@ -131,8 +121,8 @@ module Lolcommits
         puts '----------------------------------------'
 
         {
-          'access_token' => access_token.token,
-          'secret'       => access_token.secret
+          access_token: access_token.token,
+          secret: access_token.secret
         }
       end
 
@@ -141,15 +131,15 @@ module Lolcommits
         tumblr_name = parse_user_input(gets.strip)
         print "\n* Automatically open Tumblr URL after posting (y/N): "
         open_url = ask_yes_or_no?
-        { 'tumblr_name' => tumblr_name, 'open_url' => open_url }
+        { tumblr_name: tumblr_name, open_url: open_url }
       end
 
       def client
         @client ||= ::Tumblr.new(
           consumer_key: TUMBLR_CONSUMER_KEY,
           consumer_secret: TUMBLR_CONSUMER_SECRET,
-          oauth_token: configuration['access_token'],
-          oauth_token_secret: configuration['secret']
+          oauth_token: configuration[:access_token],
+          oauth_token_secret: configuration[:secret]
         )
       end
 
@@ -170,7 +160,7 @@ module Lolcommits
       end
 
       def tumblr_post_url(post)
-        "https://#{configuration['tumblr_name']}.tumblr.com/post/#{post['id']}"
+        "https://#{configuration[:tumblr_name]}.tumblr.com/post/#{post['id']}"
       end
 
       def open_url(url)

--- a/lib/lolcommits/tumblr/version.rb
+++ b/lib/lolcommits/tumblr/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Tumblr
-    VERSION = "0.0.3".freeze
+    VERSION = "0.0.4".freeze
   end
 end

--- a/lolcommits-tumblr.gemspec
+++ b/lolcommits-tumblr.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('webrick')
   spec.add_runtime_dependency('oauth')
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-# necessary libs from lolcommits (allowing plugin to run)
-require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+# lolcommits gem
+require 'lolcommits'
 
 # lolcommit test helpers
 require 'lolcommits/test_helpers/git_repo'


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* update rubies for Travis CI
* bump gem version (for new plugin release)