### PR TITLE
Support templated captions in Tumblr posts

### DIFF
--- a/lib/lolcommits/plugin/tumblr.rb
+++ b/lib/lolcommits/plugin/tumblr.rb
@@ -1,9 +1,11 @@
+require 'pp'
 require 'lolcommits/plugin/base'
 require 'lolcommits/cli/launcher'
 require 'oauth'
 require 'webrick'
 require 'cgi'
 require 'tumblr_client'
+require 'erb'
 
 module Lolcommits
   module Plugin
@@ -31,7 +33,16 @@ module Lolcommits
       #
       def run_capture_ready
         print "*** Posting to Tumblr ... "
-        post = client.photo(configuration[:tumblr_name], data: runner.main_image)
+        if configuration[:caption]
+          tplvars = binding
+          tplvars.local_variable_set(:runner, runner)
+          tplvars.local_variable_set(:vcs_info, runner.vcs_info)          
+          caption = ERB.new(configuration[:caption]).result(tplvars)
+        else
+          caption = nil
+        end
+        p caption
+        post = client.photo(configuration[:tumblr_name], data: runner.main_image, caption: caption)
 
         if post.key?('id')
           post_url = tumblr_post_url(post)

--- a/lib/lolcommits/plugin/tumblr.rb
+++ b/lib/lolcommits/plugin/tumblr.rb
@@ -1,4 +1,3 @@
-require 'pp'
 require 'lolcommits/plugin/base'
 require 'lolcommits/cli/launcher'
 require 'oauth'


### PR DESCRIPTION
With this you can set a caption in lolcommits config.yml, eg

```
tumblr:
  :caption: "HECK YEAH! <%= runner.sha %> in <%= vcs_info.repo %> on <%= vcs_info.branch %> - <%= runner.message %>"
```

And the Tumblr post will have a populated caption.

Template string is passed variables `runner` and `vcs_info` (latter already a property of runner, figured I'd bring it to the top).

Made this for my own use, I'm no Ruby expert so happy for any feedback!

Note that it introduces a `require 'erb'`, not sure if that's the best/right way to evaluate a `config.yml` string as a template.

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [x] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [x] If relevant, mention GitHub issue number above and include in a commit message.
- [x] Latest code from master merged.
- [ ] New behaviour has test coverage.
- [ ] Avoid duplicating code.
- [ ] No commented out code.
- [ ] Avoid comments for your code, write code that explains itself.
- [ ] Changes are simple, useful, clear and brief.
